### PR TITLE
Add ongoing order banner to dashboard

### DIFF
--- a/foodify-driver/package-lock.json
+++ b/foodify-driver/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.7.7",
         "expo": "~54.0.12",
         "expo-blur": "~15.0.7",
+        "expo-camera": "~17.0.8",
         "expo-location": "~19.0.7",
         "expo-secure-store": "~15.0.7",
         "expo-status-bar": "~3.0.8",
@@ -4785,6 +4786,26 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-camera": {
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-17.0.8.tgz",
+      "integrity": "sha512-BIGvS+3myaYqMtk2VXWgdcOMrewH+55BttmaYqq9tv9+o5w+RAbH9wlJSt0gdaswikiyzoWT7mOnLDleYClXmw==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
       }
     },
     "node_modules/expo-location": {

--- a/foodify-driver/package.json
+++ b/foodify-driver/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "axios": "^1.7.7",
     "expo": "~54.0.12",
-    "expo-camera": "~15.0.7",
     "expo-blur": "~15.0.7",
+    "expo-camera": "~17.0.8",
     "expo-location": "~19.0.7",
     "expo-secure-store": "~15.0.7",
     "expo-status-bar": "~3.0.8",

--- a/foodify-driver/package.json
+++ b/foodify-driver/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "axios": "^1.7.7",
     "expo": "~54.0.12",
+    "expo-camera": "~15.0.7",
     "expo-blur": "~15.0.7",
     "expo-location": "~19.0.7",
     "expo-secure-store": "~15.0.7",

--- a/foodify-driver/src/components/OngoingOrderBanner.tsx
+++ b/foodify-driver/src/components/OngoingOrderBanner.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { ScanLine } from 'lucide-react-native';
 import { moderateScale, scale, verticalScale } from 'react-native-size-matters';
 
 export interface OngoingOrderBannerProps {
@@ -65,9 +66,15 @@ export const OngoingOrderBanner: React.FC<OngoingOrderBannerProps> = ({
             onPress={onScanToPickup}
             style={[styles.secondaryAction, styles.column, styles.scanAction]}
           >
-            <Text allowFontScaling={false} style={styles.secondaryActionLabel}>
-              Scan to Pickup
-            </Text>
+            <View style={styles.scanActionContent}>
+              <ScanLine color="#ffffff" size={moderateScale(16)} />
+              <Text
+                allowFontScaling={false}
+                style={[styles.secondaryActionLabel, styles.scanActionLabel]}
+              >
+                Scan to Pickup
+              </Text>
+            </View>
           </TouchableOpacity>
         </View>
       </View>
@@ -165,5 +172,14 @@ const styles = StyleSheet.create({
   scanAction: {
     marginLeft: scale(12),
     backgroundColor: '#192038',
+  },
+  scanActionContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: scale(8),
+  },
+  scanActionLabel: {
+    textAlign: 'left',
   },
 });

--- a/foodify-driver/src/components/OngoingOrderBanner.tsx
+++ b/foodify-driver/src/components/OngoingOrderBanner.tsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { moderateScale, scale, verticalScale } from 'react-native-size-matters';
+
+export interface OngoingOrderBannerProps {
+  onCallRestaurant?: () => void;
+  onSeeOrderDetails?: () => void;
+  onLookForDirection?: () => void;
+  onScanToPickup?: () => void;
+}
+
+export const OngoingOrderBanner: React.FC<OngoingOrderBannerProps> = ({
+  onCallRestaurant,
+  onSeeOrderDetails,
+  onLookForDirection,
+  onScanToPickup,
+}) => {
+  return (
+    <View style={styles.container}>
+      <TouchableOpacity
+        activeOpacity={0.85}
+        onPress={onCallRestaurant}
+        style={styles.callButton}
+      >
+        <View style={styles.callButtonContent}>
+          <Text allowFontScaling={false} style={styles.callLabel}>
+            Call Restaurant
+          </Text>
+          <Text allowFontScaling={false} style={styles.callIcon}>
+            📞
+          </Text>
+        </View>
+      </TouchableOpacity>
+
+      <View style={styles.card}>
+        <View style={styles.row}>
+          <View style={styles.column}>
+            <Text allowFontScaling={false} style={styles.title}>
+              Your order
+            </Text>
+          </View>
+          <TouchableOpacity
+            activeOpacity={0.85}
+            onPress={onSeeOrderDetails}
+            style={[styles.column, styles.primaryAction]}
+          >
+            <Text allowFontScaling={false} style={styles.primaryActionLabel}>
+              See order details
+            </Text>
+          </TouchableOpacity>
+        </View>
+
+        <View style={[styles.row, styles.bottomRow]}>
+          <TouchableOpacity
+            activeOpacity={0.85}
+            onPress={onLookForDirection}
+            style={[styles.secondaryAction, styles.column]}
+          >
+            <Text allowFontScaling={false} style={styles.secondaryActionLabel}>
+              Look for direction
+            </Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            activeOpacity={0.85}
+            onPress={onScanToPickup}
+            style={[styles.secondaryAction, styles.column, styles.scanAction]}
+          >
+            <Text allowFontScaling={false} style={styles.secondaryActionLabel}>
+              Scan to Pickup
+            </Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    width: '100%',
+    maxWidth: moderateScale(380),
+  },
+  callButton: {
+    backgroundColor: '#27C36F',
+    borderRadius: moderateScale(28),
+    paddingVertical: verticalScale(10),
+    paddingHorizontal: scale(24),
+    marginBottom: verticalScale(14),
+    shadowColor: '#27C36F',
+    shadowOpacity: 0.22,
+    shadowRadius: moderateScale(12),
+    shadowOffset: { width: 0, height: verticalScale(6) },
+    elevation: 4,
+  },
+  callButtonContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  callLabel: {
+    color: '#ffffff',
+    fontSize: moderateScale(16),
+    fontWeight: '600',
+  },
+  callIcon: {
+    fontSize: moderateScale(16),
+    color: '#ffffff',
+    marginLeft: scale(8),
+  },
+  card: {
+    backgroundColor: '#ffffff',
+    borderRadius: moderateScale(20),
+    paddingVertical: verticalScale(16),
+    paddingHorizontal: scale(20),
+    width: '100%',
+    maxWidth: moderateScale(360),
+    shadowColor: '#000000',
+    shadowOpacity: 0.12,
+    shadowRadius: moderateScale(12),
+    shadowOffset: { width: 0, height: verticalScale(6) },
+    elevation: 3,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  bottomRow: {
+    marginTop: verticalScale(16),
+  },
+  column: {
+    flex: 1,
+  },
+  title: {
+    fontSize: moderateScale(18),
+    fontWeight: '600',
+    color: '#0F172A',
+  },
+  primaryAction: {
+    backgroundColor: '#D72128',
+    borderRadius: moderateScale(14),
+    paddingVertical: verticalScale(10),
+    paddingHorizontal: scale(12),
+    marginLeft: scale(12),
+  },
+  primaryActionLabel: {
+    color: '#ffffff',
+    fontSize: moderateScale(13),
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  secondaryAction: {
+    backgroundColor: '#0B3C81',
+    borderRadius: moderateScale(14),
+    paddingVertical: verticalScale(10),
+    paddingHorizontal: scale(12),
+  },
+  secondaryActionLabel: {
+    color: '#ffffff',
+    fontSize: moderateScale(13),
+    fontWeight: '600',
+    textAlign: 'center',
+  },
+  scanAction: {
+    marginLeft: scale(12),
+    backgroundColor: '#192038',
+  },
+});

--- a/foodify-driver/src/components/OngoingOrderDetailsOverlay.tsx
+++ b/foodify-driver/src/components/OngoingOrderDetailsOverlay.tsx
@@ -1,0 +1,319 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { moderateScale, scale, verticalScale } from 'react-native-size-matters';
+
+export interface OngoingOrderDetailsOverlayProps {
+  onClose: () => void;
+}
+
+export const OngoingOrderDetailsOverlay: React.FC<OngoingOrderDetailsOverlayProps> = ({
+  onClose,
+}) => {
+  return (
+    <View pointerEvents="box-none" style={styles.container}>
+      <View style={styles.card}>
+        <View style={styles.headerBackground}>
+          <Text allowFontScaling={false} style={styles.headerTitle}>
+            Your Order Details
+          </Text>
+          <TouchableOpacity
+            accessibilityLabel="Close order details"
+            activeOpacity={0.85}
+            onPress={onClose}
+            style={styles.closeButton}
+          >
+            <Text allowFontScaling={false} style={styles.closeLabel}>
+              ×
+            </Text>
+          </TouchableOpacity>
+        </View>
+
+        <View style={styles.content}>
+          <View style={styles.restaurantRow}>
+            <View style={styles.productBadge}>
+              <Text allowFontScaling={false} style={styles.productBadgeText}>
+                4
+              </Text>
+            </View>
+            <Text allowFontScaling={false} style={styles.restaurantLabel}>
+              Product from <Text style={styles.restaurantName}>The Hood</Text>
+            </Text>
+            <Text allowFontScaling={false} style={styles.dropdownIcon}>
+              ˅
+            </Text>
+          </View>
+
+          <View style={styles.section}>
+            <Text allowFontScaling={false} style={styles.sectionLabel}>
+              Comment
+            </Text>
+            <View style={styles.commentBox}>
+              <Text allowFontScaling={false} style={styles.commentText}>
+                marquez le sandwich sans harissa
+              </Text>
+            </View>
+          </View>
+
+          <View style={styles.section}>
+            <Text allowFontScaling={false} style={styles.sectionLabel}>
+              Delivery Address
+            </Text>
+            <View style={styles.addressBox}>
+              <Text allowFontScaling={false} style={styles.addressText}>
+                Rue Mustapha Abdessalem, Ariana 2091
+              </Text>
+            </View>
+          </View>
+
+          <View style={styles.section}>
+            <Text allowFontScaling={false} style={styles.sectionLabel}>
+              Payment method
+            </Text>
+            <View style={styles.paymentRow}>
+              <View style={styles.paymentIcon}>
+                <Text allowFontScaling={false} style={styles.paymentIconText}>
+                  💳
+                </Text>
+              </View>
+              <Text allowFontScaling={false} style={styles.paymentText}>
+                Pay by Credit Card
+              </Text>
+            </View>
+          </View>
+
+          <View style={styles.divider} />
+
+          <View style={styles.summaryRow}>
+            <Text allowFontScaling={false} style={styles.summaryLabel}>
+              Subtotal
+            </Text>
+            <Text allowFontScaling={false} style={styles.summaryValue}>
+              xx.00 dt
+            </Text>
+          </View>
+          <View style={styles.summaryRow}>
+            <Text allowFontScaling={false} style={styles.summaryLabel}>
+              Fees
+            </Text>
+            <Text allowFontScaling={false} style={styles.summaryValue}>
+              xx.00 dt
+            </Text>
+          </View>
+          <View style={styles.summaryRow}>
+            <Text allowFontScaling={false} style={styles.summaryLabel}>
+              Delivery
+            </Text>
+            <Text allowFontScaling={false} style={styles.summaryValue}>
+              xx.00 dt
+            </Text>
+          </View>
+          <View style={styles.summaryRow}>
+            <Text allowFontScaling={false} style={styles.summaryLabel}>
+              Tips
+            </Text>
+            <Text allowFontScaling={false} style={styles.summaryValue}>
+              xx.00 dt
+            </Text>
+          </View>
+
+          <View style={styles.totalRow}>
+            <Text allowFontScaling={false} style={styles.totalLabel}>
+              Total
+            </Text>
+            <Text allowFontScaling={false} style={styles.totalValue}>
+              xx.00 dt
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'flex-start',
+    alignItems: 'center',
+    paddingTop: verticalScale(60),
+    paddingHorizontal: moderateScale(24),
+  },
+  card: {
+    width: '100%',
+    maxWidth: moderateScale(370),
+    borderRadius: moderateScale(24),
+    backgroundColor: '#ffffff',
+    shadowColor: 'rgba(15, 23, 42, 0.18)',
+    shadowOffset: { width: 0, height: verticalScale(14) },
+    shadowOpacity: 1,
+    shadowRadius: moderateScale(26),
+    elevation: moderateScale(16),
+    overflow: 'hidden',
+  },
+  headerBackground: {
+    backgroundColor: '#CA251B',
+    paddingVertical: verticalScale(14),
+    paddingHorizontal: moderateScale(20),
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  headerTitle: {
+    fontSize: moderateScale(16),
+    fontWeight: '700',
+    color: '#ffffff',
+    letterSpacing: moderateScale(0.6),
+  },
+  closeButton: {
+    width: moderateScale(32),
+    height: moderateScale(32),
+    borderRadius: moderateScale(16),
+    backgroundColor: '#ffffff',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  closeLabel: {
+    fontSize: moderateScale(18),
+    fontWeight: '700',
+    color: '#CA251B',
+    marginTop: verticalScale(-2),
+  },
+  content: {
+    paddingHorizontal: moderateScale(20),
+    paddingVertical: verticalScale(18),
+    gap: verticalScale(14),
+  },
+  restaurantRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  productBadge: {
+    width: moderateScale(28),
+    height: moderateScale(28),
+    borderRadius: moderateScale(12),
+    backgroundColor: '#CA251B',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  productBadgeText: {
+    fontSize: moderateScale(13),
+    fontWeight: '700',
+    color: '#ffffff',
+  },
+  restaurantLabel: {
+    flex: 1,
+    marginLeft: scale(12),
+    fontSize: moderateScale(14),
+    fontWeight: '600',
+    color: '#1F2937',
+  },
+  restaurantName: {
+    color: '#CA251B',
+  },
+  dropdownIcon: {
+    fontSize: moderateScale(14),
+    color: '#CA251B',
+    marginLeft: scale(12),
+  },
+  section: {
+    marginTop: verticalScale(4),
+  },
+  sectionLabel: {
+    fontSize: moderateScale(13),
+    fontWeight: '600',
+    color: '#9CA3AF',
+    marginBottom: verticalScale(6),
+  },
+  commentBox: {
+    backgroundColor: '#F3F4F6',
+    borderRadius: moderateScale(14),
+    paddingHorizontal: moderateScale(16),
+    paddingVertical: verticalScale(12),
+  },
+  commentText: {
+    fontSize: moderateScale(13),
+    color: '#4B5563',
+  },
+  addressBox: {
+    backgroundColor: '#ffffff',
+    borderRadius: moderateScale(14),
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: '#E5E7EB',
+    paddingHorizontal: moderateScale(16),
+    paddingVertical: verticalScale(12),
+    shadowColor: 'rgba(15, 23, 42, 0.06)',
+    shadowOffset: { width: 0, height: verticalScale(4) },
+    shadowOpacity: 1,
+    shadowRadius: moderateScale(10),
+    elevation: moderateScale(4),
+  },
+  addressText: {
+    fontSize: moderateScale(13),
+    color: '#1F2937',
+  },
+  paymentRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#F3F4F6',
+    borderRadius: moderateScale(14),
+    paddingHorizontal: moderateScale(16),
+    paddingVertical: verticalScale(12),
+    gap: scale(12),
+  },
+  paymentIcon: {
+    width: moderateScale(34),
+    height: moderateScale(34),
+    borderRadius: moderateScale(10),
+    backgroundColor: '#ffffff',
+    justifyContent: 'center',
+    alignItems: 'center',
+    shadowColor: 'rgba(15, 23, 42, 0.08)',
+    shadowOffset: { width: 0, height: verticalScale(4) },
+    shadowOpacity: 1,
+    shadowRadius: moderateScale(8),
+    elevation: moderateScale(4),
+  },
+  paymentIconText: {
+    fontSize: moderateScale(16),
+  },
+  paymentText: {
+    fontSize: moderateScale(13),
+    color: '#1F2937',
+    fontWeight: '600',
+  },
+  divider: {
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: '#E5E7EB',
+    marginVertical: verticalScale(4),
+  },
+  summaryRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  summaryLabel: {
+    fontSize: moderateScale(13),
+    color: '#6B7280',
+  },
+  summaryValue: {
+    fontSize: moderateScale(13),
+    color: '#6B7280',
+  },
+  totalRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginTop: verticalScale(4),
+    paddingTop: verticalScale(6),
+  },
+  totalLabel: {
+    fontSize: moderateScale(16),
+    fontWeight: '700',
+    color: '#111827',
+  },
+  totalValue: {
+    fontSize: moderateScale(16),
+    fontWeight: '700',
+    color: '#CA251B',
+  },
+});
+

--- a/foodify-driver/src/components/ScanToPickupOverlay.tsx
+++ b/foodify-driver/src/components/ScanToPickupOverlay.tsx
@@ -1,0 +1,265 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Modal,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import {
+  BarcodeScanningResult,
+  CameraView,
+  useCameraPermissions,
+} from 'expo-camera';
+import { BlurView } from 'expo-blur';
+import { moderateScale, scale, verticalScale } from 'react-native-size-matters';
+import { X } from 'lucide-react-native';
+
+export interface ScanToPickupOverlayProps {
+  visible: boolean;
+  onClose: () => void;
+  onScanned?: (result: BarcodeScanningResult) => void;
+}
+
+export const ScanToPickupOverlay: React.FC<ScanToPickupOverlayProps> = ({
+  visible,
+  onClose,
+  onScanned,
+}) => {
+  const [permission, requestPermission] = useCameraPermissions();
+  const [hasScanned, setHasScanned] = useState(false);
+
+  useEffect(() => {
+    if (!visible) {
+      return;
+    }
+
+    setHasScanned(false);
+
+    if (!permission || permission.status === 'undetermined') {
+      requestPermission();
+    }
+  }, [permission, requestPermission, visible]);
+
+  const handleClose = useCallback(() => {
+    setHasScanned(false);
+    onClose();
+  }, [onClose]);
+
+  const handleRequestPermission = useCallback(() => {
+    requestPermission();
+  }, [requestPermission]);
+
+  const handleBarcodeScanned = useCallback(
+    (result: BarcodeScanningResult) => {
+      if (hasScanned) {
+        return;
+      }
+
+      setHasScanned(true);
+      onScanned?.(result);
+    },
+    [hasScanned, onScanned],
+  );
+
+  const isPermissionDenied = useMemo(() => {
+    if (!permission) {
+      return false;
+    }
+
+    return permission.status === 'denied' && !permission.granted;
+  }, [permission]);
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <Modal animationType="fade" transparent visible>
+      <View style={StyleSheet.absoluteFill}>
+        <BlurView intensity={70} tint="dark" style={StyleSheet.absoluteFill} />
+
+        <View style={styles.container}>
+          <View style={styles.cameraCard}>
+            <View style={styles.header}>
+              <Text allowFontScaling={false} style={styles.title}>
+                Scan order QR code
+              </Text>
+
+              <TouchableOpacity
+                accessibilityRole="button"
+                accessibilityLabel="Close scanner"
+                onPress={handleClose}
+                style={styles.closeButton}
+                activeOpacity={0.85}
+              >
+                <X color="#0F172A" size={moderateScale(18)} />
+              </TouchableOpacity>
+            </View>
+
+            <View style={styles.cameraWrapper}>
+              {!permission ? (
+                <View style={styles.permissionPlaceholder}>
+                  <ActivityIndicator color="#CA251B" size="large" />
+                  <Text allowFontScaling={false} style={styles.permissionText}>
+                    Preparing camera…
+                  </Text>
+                </View>
+              ) : permission.granted ? (
+                <CameraView
+                  style={StyleSheet.absoluteFill}
+                  facing="back"
+                  barcodeScannerSettings={{ barcodeTypes: ['qr'] }}
+                  onBarcodeScanned={handleBarcodeScanned}
+                >
+                  <View style={styles.overlay}>
+                    <View style={styles.focusFrame} />
+                    <Text allowFontScaling={false} style={styles.instructions}>
+                      Align the QR code within the frame
+                    </Text>
+                  </View>
+                </CameraView>
+              ) : (
+                <View style={styles.permissionPlaceholder}>
+                  <Text allowFontScaling={false} style={styles.permissionTitle}>
+                    Camera access needed
+                  </Text>
+                  <Text allowFontScaling={false} style={styles.permissionText}>
+                    Enable camera permission to scan the pickup QR code.
+                  </Text>
+
+                  {isPermissionDenied && !permission.canAskAgain ? (
+                    <Text
+                      allowFontScaling={false}
+                      style={styles.permissionHelpText}
+                    >
+                      You can enable camera access from your device settings.
+                    </Text>
+                  ) : (
+                    <TouchableOpacity
+                      onPress={handleRequestPermission}
+                      activeOpacity={0.85}
+                      style={styles.permissionButton}
+                    >
+                      <Text
+                        allowFontScaling={false}
+                        style={styles.permissionButtonLabel}
+                      >
+                        Allow camera access
+                      </Text>
+                    </TouchableOpacity>
+                  )}
+                </View>
+              )}
+            </View>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: scale(20),
+  },
+  cameraCard: {
+    width: '100%',
+    maxWidth: moderateScale(360),
+    borderRadius: moderateScale(24),
+    backgroundColor: '#ffffff',
+    overflow: 'hidden',
+    padding: scale(16),
+    shadowColor: 'rgba(0, 0, 0, 0.4)',
+    shadowOpacity: 0.25,
+    shadowOffset: { width: 0, height: verticalScale(10) },
+    shadowRadius: moderateScale(24),
+    elevation: moderateScale(8),
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: verticalScale(12),
+  },
+  title: {
+    fontSize: moderateScale(18),
+    fontWeight: '700',
+    color: '#0F172A',
+  },
+  closeButton: {
+    width: moderateScale(34),
+    height: moderateScale(34),
+    borderRadius: moderateScale(17),
+    backgroundColor: '#F1F5F9',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  cameraWrapper: {
+    position: 'relative',
+    width: '100%',
+    height: verticalScale(320),
+    borderRadius: moderateScale(18),
+    overflow: 'hidden',
+    backgroundColor: '#0F172A',
+  },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: scale(16),
+    gap: verticalScale(16),
+  },
+  focusFrame: {
+    width: '70%',
+    aspectRatio: 1,
+    borderWidth: moderateScale(4),
+    borderColor: '#ffffff',
+    borderRadius: moderateScale(20),
+    backgroundColor: 'rgba(0, 0, 0, 0.15)',
+  },
+  instructions: {
+    color: '#ffffff',
+    fontSize: moderateScale(14),
+    textAlign: 'center',
+    fontWeight: '500',
+  },
+  permissionPlaceholder: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: scale(24),
+    gap: verticalScale(12),
+  },
+  permissionTitle: {
+    fontSize: moderateScale(16),
+    fontWeight: '700',
+    color: '#0F172A',
+    textAlign: 'center',
+  },
+  permissionText: {
+    fontSize: moderateScale(14),
+    color: '#334155',
+    textAlign: 'center',
+  },
+  permissionButton: {
+    marginTop: verticalScale(8),
+    backgroundColor: '#CA251B',
+    borderRadius: moderateScale(16),
+    paddingVertical: verticalScale(10),
+    paddingHorizontal: scale(20),
+  },
+  permissionButtonLabel: {
+    color: '#ffffff',
+    fontSize: moderateScale(14),
+    fontWeight: '600',
+  },
+  permissionHelpText: {
+    fontSize: moderateScale(13),
+    color: '#64748B',
+    textAlign: 'center',
+  },

--- a/foodify-driver/src/components/ScanToPickupOverlay.tsx
+++ b/foodify-driver/src/components/ScanToPickupOverlay.tsx
@@ -263,3 +263,4 @@ const styles = StyleSheet.create({
     color: '#64748B',
     textAlign: 'center',
   },
+})

--- a/foodify-driver/src/screens/Home/DashboardScreen.tsx
+++ b/foodify-driver/src/screens/Home/DashboardScreen.tsx
@@ -15,6 +15,7 @@ import { BlurView } from 'expo-blur';
 import { useAuth } from '../../contexts/AuthContext';
 import { IncomingOrderOverlay } from '../../components/IncomingOrderOverlay';
 import { OngoingOrderBanner } from '../../components/OngoingOrderBanner';
+import { OngoingOrderDetailsOverlay } from '../../components/OngoingOrderDetailsOverlay';
 
 const DEFAULT_REGION = {
   latitude: 47.5726,
@@ -32,6 +33,7 @@ export const DashboardScreen: React.FC = () => {
   const [isIncomingOrderVisible, setIncomingOrderVisible] = useState<boolean>(true);
   const [isOngoingOrderVisible, setOngoingOrderVisible] = useState<boolean>(false);
   const [incomingCountdown, setIncomingCountdown] = useState<number>(89);
+  const [isOrderDetailsVisible, setOrderDetailsVisible] = useState<boolean>(false);
 
   useEffect(() => {
     let isMounted = true;
@@ -120,6 +122,7 @@ export const DashboardScreen: React.FC = () => {
 
   const handleSeeOrderDetails = useCallback(() => {
     console.log('See order details pressed');
+    setOrderDetailsVisible(true);
   }, []);
 
   const handleLookForDirection = useCallback(() => {
@@ -128,6 +131,10 @@ export const DashboardScreen: React.FC = () => {
 
   const handleScanToPickup = useCallback(() => {
     console.log('Scan to Pickup pressed');
+  }, []);
+
+  const handleCloseOrderDetails = useCallback(() => {
+    setOrderDetailsVisible(false);
   }, []);
 
   return (
@@ -233,6 +240,12 @@ export const DashboardScreen: React.FC = () => {
               orderLabel="New Order"
               subtitle="You have a new pickup request"
             />
+          </>
+        )}
+        {isOrderDetailsVisible && (
+          <>
+            <BlurView intensity={45} tint="dark" style={styles.blurOverlay} />
+            <OngoingOrderDetailsOverlay onClose={handleCloseOrderDetails} />
           </>
         )}
       </View>

--- a/foodify-driver/src/screens/Home/DashboardScreen.tsx
+++ b/foodify-driver/src/screens/Home/DashboardScreen.tsx
@@ -14,6 +14,7 @@ import { BlurView } from 'expo-blur';
 
 import { useAuth } from '../../contexts/AuthContext';
 import { IncomingOrderOverlay } from '../../components/IncomingOrderOverlay';
+import { OngoingOrderBanner } from '../../components/OngoingOrderBanner';
 
 const DEFAULT_REGION = {
   latitude: 47.5726,
@@ -29,6 +30,7 @@ export const DashboardScreen: React.FC = () => {
   const [userRegion, setUserRegion] = useState<Region | null>(null);
   const mapRef = useRef<MapView | null>(null);
   const [isIncomingOrderVisible, setIncomingOrderVisible] = useState<boolean>(true);
+  const [isOngoingOrderVisible, setOngoingOrderVisible] = useState<boolean>(false);
   const [incomingCountdown, setIncomingCountdown] = useState<number>(89);
 
   useEffect(() => {
@@ -104,10 +106,28 @@ export const DashboardScreen: React.FC = () => {
 
   const handleAcceptOrder = useCallback(() => {
     setIncomingOrderVisible(false);
+    setOngoingOrderVisible(true);
   }, []);
 
   const handleDeclineOrder = useCallback(() => {
     setIncomingOrderVisible(false);
+    setOngoingOrderVisible(false);
+  }, []);
+
+  const handleCallRestaurant = useCallback(() => {
+    console.log('Call Restaurant pressed');
+  }, []);
+
+  const handleSeeOrderDetails = useCallback(() => {
+    console.log('See order details pressed');
+  }, []);
+
+  const handleLookForDirection = useCallback(() => {
+    console.log('Look for direction pressed');
+  }, []);
+
+  const handleScanToPickup = useCallback(() => {
+    console.log('Scan to Pickup pressed');
   }, []);
 
   return (
@@ -159,13 +179,24 @@ export const DashboardScreen: React.FC = () => {
               </TouchableOpacity>
             </View>
 
-            <TouchableOpacity activeOpacity={0.85} style={styles.goButton}>
-              <View style={styles.goRing}>
-                <Text allowFontScaling={false} style={styles.goLabel}>
-                  GO!
-                </Text>
-              </View>
-            </TouchableOpacity>
+            <View style={styles.overlayBottomContainer}>
+              {isOngoingOrderVisible ? (
+                <OngoingOrderBanner
+                  onCallRestaurant={handleCallRestaurant}
+                  onSeeOrderDetails={handleSeeOrderDetails}
+                  onLookForDirection={handleLookForDirection}
+                  onScanToPickup={handleScanToPickup}
+                />
+              ) : (
+                <TouchableOpacity activeOpacity={0.85} style={styles.goButton}>
+                  <View style={styles.goRing}>
+                    <Text allowFontScaling={false} style={styles.goLabel}>
+                      GO!
+                    </Text>
+                  </View>
+                </TouchableOpacity>
+              )}
+            </View>
           </View>
         </View>
 
@@ -418,6 +449,10 @@ const styles = StyleSheet.create({
     fontWeight: '800',
     color: '#ffffff',
     letterSpacing: moderateScale(1.2),
+  },
+  overlayBottomContainer: {
+    alignItems: 'center',
+    width: '100%',
   },
   footer: {
     backgroundColor: '#ffffff',

--- a/foodify-driver/src/screens/Home/DashboardScreen.tsx
+++ b/foodify-driver/src/screens/Home/DashboardScreen.tsx
@@ -10,12 +10,14 @@ import {
 import { moderateScale, verticalScale } from 'react-native-size-matters';
 import MapView, { Marker, Region } from 'react-native-maps';
 import * as Location from 'expo-location';
+import { BarcodeScanningResult } from 'expo-camera';
 import { BlurView } from 'expo-blur';
 
 import { useAuth } from '../../contexts/AuthContext';
 import { IncomingOrderOverlay } from '../../components/IncomingOrderOverlay';
 import { OngoingOrderBanner } from '../../components/OngoingOrderBanner';
 import { OngoingOrderDetailsOverlay } from '../../components/OngoingOrderDetailsOverlay';
+import { ScanToPickupOverlay } from '../../components/ScanToPickupOverlay';
 
 const DEFAULT_REGION = {
   latitude: 47.5726,
@@ -34,6 +36,7 @@ export const DashboardScreen: React.FC = () => {
   const [isOngoingOrderVisible, setOngoingOrderVisible] = useState<boolean>(false);
   const [incomingCountdown, setIncomingCountdown] = useState<number>(89);
   const [isOrderDetailsVisible, setOrderDetailsVisible] = useState<boolean>(false);
+  const [isScanOverlayVisible, setScanOverlayVisible] = useState<boolean>(false);
 
   useEffect(() => {
     let isMounted = true;
@@ -130,11 +133,20 @@ export const DashboardScreen: React.FC = () => {
   }, []);
 
   const handleScanToPickup = useCallback(() => {
-    console.log('Scan to Pickup pressed');
+    setScanOverlayVisible(true);
   }, []);
 
   const handleCloseOrderDetails = useCallback(() => {
     setOrderDetailsVisible(false);
+  }, []);
+
+  const handleCloseScanner = useCallback(() => {
+    setScanOverlayVisible(false);
+  }, []);
+
+  const handleQRCodeScanned = useCallback((result: BarcodeScanningResult) => {
+    console.log('QR code scanned:', result.data);
+    setScanOverlayVisible(false);
   }, []);
 
   return (
@@ -247,6 +259,13 @@ export const DashboardScreen: React.FC = () => {
             <BlurView intensity={45} tint="dark" style={styles.blurOverlay} />
             <OngoingOrderDetailsOverlay onClose={handleCloseOrderDetails} />
           </>
+        )}
+        {isScanOverlayVisible && (
+          <ScanToPickupOverlay
+            onClose={handleCloseScanner}
+            onScanned={handleQRCodeScanned}
+            visible={isScanOverlayVisible}
+          />
         )}
       </View>
     </SafeAreaView>


### PR DESCRIPTION
## Summary
- add an ongoing order banner component with quick action buttons
- show the banner on the dashboard once an incoming order is accepted

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_b_68e309b66ccc832ca78ad6ac718b44b7