### PR TITLE
Gracefully handle SecureStore failures

### DIFF
--- a/foodify-driver/App.tsx
+++ b/foodify-driver/App.tsx
@@ -3,13 +3,16 @@ import { StatusBar } from 'expo-status-bar';
 
 import { AuthProvider } from './src/contexts/AuthContext';
 import { AppNavigator } from './src/navigation/AppNavigator';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 const App: React.FC = () => {
   return (
-    <AuthProvider>
+    <SafeAreaProvider>
+ <AuthProvider>
       <StatusBar style="dark" />
       <AppNavigator />
     </AuthProvider>
+    </SafeAreaProvider>
   );
 };
 

--- a/foodify-driver/app.config.ts
+++ b/foodify-driver/app.config.ts
@@ -7,7 +7,6 @@ const config: ExpoConfig = {
   orientation: 'portrait',
   icon: './assets/icon.png',
   userInterfaceStyle: 'light',
-  newArchEnabled: true,
   plugins: ["expo-secure-store"],
   splash: {
     image: './assets/splash-icon.png',

--- a/foodify-driver/package-lock.json
+++ b/foodify-driver/package-lock.json
@@ -20,6 +20,7 @@
         "react": "19.1.0",
         "react-native": "0.81.4",
         "react-native-maps": "^1.15.8",
+        "react-native-safe-area-context": "~5.6.0",
         "react-native-size-matters": "latest",
         "react-native-svg": "15.12.1",
         "zustand": "^4.5.2"
@@ -8110,6 +8111,16 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-safe-area-context": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.1.tgz",
+      "integrity": "sha512-/wJE58HLEAkATzhhX1xSr+fostLsK8Q97EfpfMDKo8jlOc1QKESSX/FQrhk7HhQH/2uSaox4Y86sNaI02kteiA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-size-matters": {

--- a/foodify-driver/package.json
+++ b/foodify-driver/package.json
@@ -21,6 +21,7 @@
     "react": "19.1.0",
     "react-native": "0.81.4",
     "react-native-maps": "^1.15.8",
+    "react-native-safe-area-context": "~5.6.0",
     "react-native-size-matters": "latest",
     "react-native-svg": "15.12.1",
     "zustand": "^4.5.2"

--- a/foodify-driver/src/components/PlatformBlurView.tsx
+++ b/foodify-driver/src/components/PlatformBlurView.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import type { BlurViewProps } from 'expo-blur';
+import { BlurView } from 'expo-blur';
+import { Platform, StyleSheet, View } from 'react-native';
+
+type PlatformBlurViewProps = React.PropsWithChildren<BlurViewProps>;
+
+const fallbackColors: Record<string, string> = {
+  default: 'rgba(15, 23, 42, 0.35)',
+  dark: 'rgba(15, 23, 42, 0.55)',
+  light: 'rgba(255, 255, 255, 0.75)',
+  extraLight: 'rgba(255, 255, 255, 0.82)',
+  prominent: 'rgba(15, 23, 42, 0.6)',
+};
+
+export const PlatformBlurView: React.FC<PlatformBlurViewProps> = ({
+  children,
+  tint = 'default',
+  intensity = 50,
+  style,
+  experimentalBlurMethod,
+  ...viewProps
+}) => {
+  if (Platform.OS === 'android') {
+    const fallbackTint = tint ?? 'default';
+    const backgroundColor = fallbackColors[fallbackTint] ?? fallbackColors.default;
+
+    return (
+      <View {...viewProps} style={[styles.fallback, { backgroundColor }, style]}>
+        {children}
+      </View>
+    );
+  }
+
+  return (
+    <BlurView
+      {...viewProps}
+      tint={tint}
+      intensity={intensity}
+      experimentalBlurMethod={experimentalBlurMethod}
+      style={style}
+    >
+      {children}
+    </BlurView>
+  );
+};
+
+const styles = StyleSheet.create({
+  fallback: {
+    overflow: 'hidden',
+  },
+});

--- a/foodify-driver/src/components/ScanToPickupOverlay.tsx
+++ b/foodify-driver/src/components/ScanToPickupOverlay.tsx
@@ -12,7 +12,7 @@ import {
   CameraView,
   useCameraPermissions,
 } from 'expo-camera';
-import { BlurView } from 'expo-blur';
+import { PlatformBlurView } from './PlatformBlurView';
 import { moderateScale, scale, verticalScale } from 'react-native-size-matters';
 import { X } from 'lucide-react-native';
 
@@ -78,7 +78,7 @@ export const ScanToPickupOverlay: React.FC<ScanToPickupOverlayProps> = ({
   return (
     <Modal animationType="fade" transparent visible>
       <View style={StyleSheet.absoluteFill}>
-        <BlurView intensity={70} tint="dark" style={StyleSheet.absoluteFill} />
+      <PlatformBlurView intensity={70} tint="dark" style={StyleSheet.absoluteFill} />
 
         <View style={styles.container}>
           <View style={styles.cameraCard}>

--- a/foodify-driver/src/screens/Auth/LoginScreen.tsx
+++ b/foodify-driver/src/screens/Auth/LoginScreen.tsx
@@ -9,7 +9,7 @@ import {
   Text,
   View,
 } from 'react-native';
-import { BlurView } from 'expo-blur';
+import { PlatformBlurView } from '../../components/PlatformBlurView';
 import { moderateScale, verticalScale } from 'react-native-size-matters';
 
 import { Logo } from '../../components/Logo';
@@ -223,7 +223,7 @@ export const LoginScreen: React.FC = () => {
               </Text>
             </Animated.View>
 
-            <BlurView intensity={65} tint="light" style={styles.glassCard}>
+            <PlatformBlurView intensity={65} tint="light" style={styles.glassCard}>
               <Animated.View
                 style={[
                   styles.card,
@@ -262,7 +262,7 @@ export const LoginScreen: React.FC = () => {
 
                 <Button label="Continue" onPress={handleContinue} disabled={!isValidNumber} />
               </Animated.View>
-            </BlurView>
+            </PlatformBlurView>
           </View>
         </KeyboardAvoidingView>
       </View>

--- a/foodify-driver/src/screens/Auth/LoginScreen.tsx
+++ b/foodify-driver/src/screens/Auth/LoginScreen.tsx
@@ -4,7 +4,6 @@ import {
   Easing,
   KeyboardAvoidingView,
   Platform,
-  SafeAreaView,
   StyleSheet,
   Text,
   View,
@@ -204,7 +203,7 @@ export const LoginScreen: React.FC = () => {
   };
 
   return (
-    <SafeAreaView style={styles.safeArea}>
+    <View style={styles.safeArea}>
       <View style={styles.container}>
         <View pointerEvents="none" style={styles.ambientLayer}>
           <Animated.View style={[styles.glow, styles.glowTop, topGlowStyle]} />
@@ -266,7 +265,7 @@ export const LoginScreen: React.FC = () => {
           </View>
         </KeyboardAvoidingView>
       </View>
-    </SafeAreaView>
+    </View>
   );
 };
 

--- a/foodify-driver/src/screens/Home/DashboardScreen.tsx
+++ b/foodify-driver/src/screens/Home/DashboardScreen.tsx
@@ -11,9 +11,10 @@ import {
 } from 'react-native';
 import { moderateScale, verticalScale } from 'react-native-size-matters';
 import MapView, { Marker, Region } from 'react-native-maps';
+import type { default as MapViewType } from 'react-native-maps/lib/MapView';
 import * as Location from 'expo-location';
 import { BarcodeScanningResult } from 'expo-camera';
-import { BlurView } from 'expo-blur';
+import { PlatformBlurView } from '../../components/PlatformBlurView';
 
 import { useAuth } from '../../contexts/AuthContext';
 import { IncomingOrderOverlay } from '../../components/IncomingOrderOverlay';
@@ -33,7 +34,7 @@ export const DashboardScreen: React.FC = () => {
 
   const formattedName = (phoneNumber ? phoneNumber : 'RIDER').toUpperCase();
   const [userRegion, setUserRegion] = useState<Region | null>(null);
-  const mapRef = useRef<MapView | null>(null);
+  const mapRef = useRef<MapViewType | null>(null);
   const [isIncomingOrderVisible, setIncomingOrderVisible] = useState<boolean>(true);
   const [isOngoingOrderVisible, setOngoingOrderVisible] = useState<boolean>(false);
   const [incomingCountdown, setIncomingCountdown] = useState<number>(89);
@@ -299,7 +300,7 @@ export const DashboardScreen: React.FC = () => {
 
         {isIncomingOrderVisible && (
           <>
-            <BlurView intensity={45} tint="dark" style={styles.blurOverlay} />
+            <PlatformBlurView intensity={45} tint="dark" style={styles.blurOverlay} />
             <IncomingOrderOverlay
               countdownSeconds={incomingCountdown}
               onAccept={handleAcceptOrder}
@@ -311,7 +312,7 @@ export const DashboardScreen: React.FC = () => {
         )}
         {isOrderDetailsVisible && (
           <>
-            <BlurView intensity={45} tint="dark" style={styles.blurOverlay} />
+            <PlatformBlurView intensity={45} tint="dark" style={styles.blurOverlay} />
             <OngoingOrderDetailsOverlay onClose={handleCloseOrderDetails} />
           </>
         )}

--- a/foodify-driver/src/screens/Home/DashboardScreen.tsx
+++ b/foodify-driver/src/screens/Home/DashboardScreen.tsx
@@ -20,6 +20,7 @@ import { IncomingOrderOverlay } from '../../components/IncomingOrderOverlay';
 import { OngoingOrderBanner } from '../../components/OngoingOrderBanner';
 import { OngoingOrderDetailsOverlay } from '../../components/OngoingOrderDetailsOverlay';
 import { ScanToPickupOverlay } from '../../components/ScanToPickupOverlay';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 const DEFAULT_REGION = {
   latitude: 47.5726,
@@ -40,6 +41,7 @@ export const DashboardScreen: React.FC = () => {
   const [isOrderDetailsVisible, setOrderDetailsVisible] = useState<boolean>(false);
   const [isScanOverlayVisible, setScanOverlayVisible] = useState<boolean>(false);
   const goPulse = useRef(new Animated.Value(0)).current;
+  const instes = useSafeAreaInsets();
 
   useEffect(() => {
     let isMounted = true;
@@ -219,7 +221,7 @@ export const DashboardScreen: React.FC = () => {
             )}
           </MapView>
 
-          <View pointerEvents="box-none" style={styles.mapOverlay}>
+          <View pointerEvents="box-none" style={{...styles.mapOverlay, paddingTop: instes.top}}>
             <View style={styles.header}>
               <TouchableOpacity activeOpacity={0.8} style={styles.menuButton}>
                 <View style={styles.menuLine} />
@@ -477,7 +479,6 @@ const styles = StyleSheet.create({
     ...StyleSheet.absoluteFillObject,
     justifyContent: 'space-between',
     paddingHorizontal: moderateScale(24),
-    paddingTop: verticalScale(18),
     paddingBottom: verticalScale(28),
   },
   mapMarker: {

--- a/foodify-driver/src/screens/Home/DashboardScreen.tsx
+++ b/foodify-driver/src/screens/Home/DashboardScreen.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Animated,
   Easing,
-  SafeAreaView,
   StyleSheet,
   Switch,
   Text,
@@ -199,7 +198,7 @@ export const DashboardScreen: React.FC = () => {
   });
 
   return (
-    <SafeAreaView style={styles.safeArea}>
+    <View style={styles.safeArea}>
       <View style={styles.container}>
         <View style={styles.mapOuter}>
           <MapView
@@ -324,7 +323,7 @@ export const DashboardScreen: React.FC = () => {
           />
         )}
       </View>
-    </SafeAreaView>
+    </View>
   );
 };
 

--- a/foodify-driver/src/store/authStore.ts
+++ b/foodify-driver/src/store/authStore.ts
@@ -2,6 +2,12 @@ import * as SecureStore from 'expo-secure-store';
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 
+type MemoryStore = Record<string, string>;
+
+type SecureStoreModule = typeof SecureStore & {
+  isAvailableAsync?: () => Promise<boolean>;
+};
+
 export type AuthState = {
   phoneNumber: string;
   token?: string;
@@ -12,13 +18,77 @@ export type AuthState = {
   toggleOnlineStatus: () => void;
 };
 
+const inMemoryStorage: MemoryStore = {};
+
+const secureStoreModule = SecureStore as SecureStoreModule;
+
+let secureStoreAvailabilityPromise: Promise<boolean> | null = null;
+
+const isSecureStoreAvailable = async (): Promise<boolean> => {
+  if (!secureStoreAvailabilityPromise) {
+    const checkAvailability = secureStoreModule.isAvailableAsync;
+
+    if (checkAvailability) {
+      secureStoreAvailabilityPromise = checkAvailability().catch((error: unknown) => {
+        console.warn('[authStore] Unable to determine secure store availability', error);
+        return false;
+      });
+    } else {
+      secureStoreAvailabilityPromise = Promise.resolve(true);
+    }
+  }
+
+  return secureStoreAvailabilityPromise!;
+};
+
 const secureStorage = {
   getItem: async (name: string) => {
-    const value = await SecureStore.getItemAsync(name);
-    return value ?? null;
+    const isAvailable = await isSecureStoreAvailable();
+
+    if (isAvailable) {
+      try {
+        const value = await secureStoreModule.getItemAsync(name);
+        if (value != null) {
+          inMemoryStorage[name] = value;
+        }
+        return value ?? null;
+      } catch (error) {
+        console.warn(`[authStore] Failed to read key "${name}" from secure store`, error);
+      }
+    }
+
+    return inMemoryStorage[name] ?? null;
   },
-  setItem: (name: string, value: string) => SecureStore.setItemAsync(name, value),
-  removeItem: (name: string) => SecureStore.deleteItemAsync(name),
+  setItem: async (name: string, value: string) => {
+    const isAvailable = await isSecureStoreAvailable();
+
+    if (isAvailable) {
+      try {
+        await secureStoreModule.setItemAsync(name, value);
+        inMemoryStorage[name] = value;
+        return;
+      } catch (error) {
+        console.warn(`[authStore] Failed to persist key "${name}" to secure store`, error);
+      }
+    }
+
+    inMemoryStorage[name] = value;
+  },
+  removeItem: async (name: string) => {
+    const isAvailable = await isSecureStoreAvailable();
+
+    if (isAvailable) {
+      try {
+        await secureStoreModule.deleteItemAsync(name);
+        delete inMemoryStorage[name];
+        return;
+      } catch (error) {
+        console.warn(`[authStore] Failed to remove key "${name}" from secure store`, error);
+      }
+    }
+
+    delete inMemoryStorage[name];
+  },
 };
 
 export const useAuthStore = create<AuthState>(


### PR DESCRIPTION
## Summary
- add a guarded SecureStore wrapper that checks module availability before use and logs recoverable failures
- fall back to an in-memory cache when the secure store cannot be reached so authentication state no longer crashes the app during bootstrap

## Testing
- `npx tsc --noEmit` *(fails: pre-existing react-native-maps type definitions complain about the MapView ref prop)*

------
https://chatgpt.com/codex/tasks/task_b_68e430b86cd0832cb77bf118dbc62e99