### PR TITLE
Implement driver login API flow

### DIFF
--- a/foodify-driver/src/navigation/AppNavigator.tsx
+++ b/foodify-driver/src/navigation/AppNavigator.tsx
@@ -5,9 +5,9 @@ import { DashboardScreen } from '../screens/Home/DashboardScreen';
 import { LoginScreen } from '../screens/Auth/LoginScreen';
 
 export const AppNavigator: React.FC = () => {
-  const { token } = useAuth();
+  const { accessToken } = useAuth();
 
-  if (!token) {
+  if (!accessToken) {
     return <LoginScreen />;
   }
 

--- a/foodify-driver/src/screens/Auth/LoginScreen.tsx
+++ b/foodify-driver/src/screens/Auth/LoginScreen.tsx
@@ -1,388 +1,159 @@
-import React, { useEffect, useMemo, useRef } from 'react';
-import {
-  Animated,
-  Easing,
-  KeyboardAvoidingView,
-  Platform,
-  StyleSheet,
-  Text,
-  View,
-} from 'react-native';
-import { PlatformBlurView } from '../../components/PlatformBlurView';
-import { moderateScale, verticalScale } from 'react-native-size-matters';
+import React, { useCallback, useMemo, useState } from 'react';
+import { KeyboardAvoidingView, Platform, StyleSheet, Text, View } from 'react-native';
+import { isAxiosError } from 'axios';
 
 import { Logo } from '../../components/Logo';
-import { Button } from '../../components/ui/Button';
 import { TextField } from '../../components/ui/TextField';
+import { Button } from '../../components/ui/Button';
 import { useAuth } from '../../contexts/AuthContext';
+import { loginDriver } from '../../services/authService';
 
 export const LoginScreen: React.FC = () => {
-  const { phoneNumber, setPhoneNumber, authenticate } = useAuth();
+  const { authenticate } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  const isValidNumber = useMemo(() => phoneNumber.trim().length >= 8, [phoneNumber]);
+  const isFormValid = useMemo(() => {
+    const trimmedEmail = email.trim();
+    return trimmedEmail.length > 0 && password.length > 0;
+  }, [email, password]);
 
-  const cardOpacity = useRef(new Animated.Value(0)).current;
-  const cardTranslateY = useRef(new Animated.Value(32)).current;
-  const topPulse = useRef(new Animated.Value(0)).current;
-  const bottomPulse = useRef(new Animated.Value(0)).current;
-  const accentPulse = useRef(new Animated.Value(0)).current;
-  const badgeFloat = useRef(new Animated.Value(0)).current;
-
-  useEffect(() => {
-    Animated.parallel([
-      Animated.timing(cardOpacity, {
-        toValue: 1,
-        duration: 450,
-        easing: Easing.out(Easing.ease),
-        useNativeDriver: true,
-      }),
-      Animated.spring(cardTranslateY, {
-        toValue: 0,
-        damping: 12,
-        mass: 0.9,
-        stiffness: 130,
-        useNativeDriver: true,
-      }),
-    ]).start();
-
-    const topLoop = Animated.loop(
-      Animated.sequence([
-        Animated.timing(topPulse, {
-          toValue: 1,
-          duration: 5200,
-          easing: Easing.inOut(Easing.sin),
-          useNativeDriver: true,
-        }),
-        Animated.timing(topPulse, {
-          toValue: 0,
-          duration: 5200,
-          easing: Easing.inOut(Easing.sin),
-          useNativeDriver: true,
-        }),
-      ]),
-    );
-
-    const bottomLoop = Animated.loop(
-      Animated.sequence([
-        Animated.timing(bottomPulse, {
-          toValue: 1,
-          duration: 6100,
-          easing: Easing.inOut(Easing.sin),
-          useNativeDriver: true,
-        }),
-        Animated.timing(bottomPulse, {
-          toValue: 0,
-          duration: 6100,
-          easing: Easing.inOut(Easing.sin),
-          useNativeDriver: true,
-        }),
-      ]),
-    );
-
-    const accentLoop = Animated.loop(
-      Animated.sequence([
-        Animated.timing(accentPulse, {
-          toValue: 1,
-          duration: 6800,
-          easing: Easing.inOut(Easing.sin),
-          useNativeDriver: true,
-        }),
-        Animated.timing(accentPulse, {
-          toValue: 0,
-          duration: 6800,
-          easing: Easing.inOut(Easing.sin),
-          useNativeDriver: true,
-        }),
-      ]),
-    );
-
-    const badgeLoop = Animated.loop(
-      Animated.sequence([
-        Animated.timing(badgeFloat, {
-          toValue: 1,
-          duration: 2800,
-          easing: Easing.inOut(Easing.sin),
-          useNativeDriver: true,
-        }),
-        Animated.timing(badgeFloat, {
-          toValue: 0,
-          duration: 2800,
-          easing: Easing.inOut(Easing.sin),
-          useNativeDriver: true,
-        }),
-      ]),
-    );
-
-    topLoop.start();
-    bottomLoop.start();
-    accentLoop.start();
-    badgeLoop.start();
-
-    return () => {
-      topLoop.stop();
-      bottomLoop.stop();
-      accentLoop.stop();
-      badgeLoop.stop();
-    };
-  }, [cardOpacity, cardTranslateY, topPulse, bottomPulse, accentPulse, badgeFloat]);
-
-  const handleContinue = () => {
-    if (!isValidNumber) {
+  const handleSubmit = useCallback(async () => {
+    if (isSubmitting || !isFormValid) {
       return;
     }
 
-    authenticate(phoneNumber, 'demo-token');
-  };
+    setIsSubmitting(true);
+    setError(null);
 
-  const topGlowStyle = {
-    transform: [
-      {
-        translateY: topPulse.interpolate({
-          inputRange: [0, 1],
-          outputRange: [0, -18],
-        }),
-      },
-      {
-        scale: topPulse.interpolate({
-          inputRange: [0, 1],
-          outputRange: [1, 1.08],
-        }),
-      },
-    ],
-  };
+    try {
+      const normalizedEmail = email.trim().toLowerCase();
+      const response = await loginDriver(normalizedEmail, password);
+      authenticate(response);
+    } catch (err: unknown) {
+      let message = 'Unable to sign in. Please try again.';
 
-  const bottomGlowStyle = {
-    transform: [
-      {
-        translateY: bottomPulse.interpolate({
-          inputRange: [0, 1],
-          outputRange: [0, 22],
-        }),
-      },
-      {
-        scale: bottomPulse.interpolate({
-          inputRange: [0, 1],
-          outputRange: [1, 1.05],
-        }),
-      },
-    ],
-  };
+      if (isAxiosError(err)) {
+        const apiMessage = err.response?.data?.message;
 
-  const accentGlowStyle = {
-    transform: [
-      {
-        translateY: accentPulse.interpolate({
-          inputRange: [0, 1],
-          outputRange: [0, -14],
-        }),
-      },
-      {
-        rotate: accentPulse.interpolate({
-          inputRange: [0, 1],
-          outputRange: ['-6deg', '6deg'],
-        }),
-      },
-      {
-        scale: accentPulse.interpolate({
-          inputRange: [0, 1],
-          outputRange: [0.92, 1.04],
-        }),
-      },
-    ],
-  };
+        if (typeof apiMessage === 'string' && apiMessage.trim().length > 0) {
+          message = apiMessage;
+        } else if (err.code === 'ECONNABORTED') {
+          message = 'Request timed out. Check your connection and try again.';
+        }
+      }
 
-  const badgeStyle = {
-    transform: [
-      {
-        translateY: badgeFloat.interpolate({
-          inputRange: [0, 1],
-          outputRange: [-4, 4],
-        }),
-      },
-    ],
-  };
+      setError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [authenticate, email, password, isFormValid, isSubmitting]);
 
   return (
-    <View style={styles.safeArea}>
-      <View style={styles.container}>
-        <View pointerEvents="none" style={styles.ambientLayer}>
-          <Animated.View style={[styles.glow, styles.glowTop, topGlowStyle]} />
-          <Animated.View style={[styles.glow, styles.glowBottom, bottomGlowStyle]} />
-          <Animated.View style={[styles.glowAccent, accentGlowStyle]} />
+    <KeyboardAvoidingView
+      behavior={Platform.select({ ios: 'padding', android: undefined })}
+      style={styles.container}
+    >
+      <View style={styles.content}>
+        <View style={styles.header}>
+          <Logo />
+          <Text allowFontScaling={false} style={styles.title}>
+            Driver sign in
+          </Text>
+          <Text allowFontScaling={false} style={styles.subtitle}>
+            Use your Foodify driver email and password to access your deliveries.
+          </Text>
         </View>
 
-        <KeyboardAvoidingView
-          behavior={Platform.select({ ios: 'padding', android: undefined })}
-          style={styles.avoidingView}
-        >
-          <View style={styles.contentWrapper}>
-            <Animated.View style={[styles.badge, badgeStyle, { opacity: cardOpacity }]}>
-              <Text allowFontScaling={false} style={styles.badgeLabel}>
-                Refreshed design • Smooth interactions
-              </Text>
-            </Animated.View>
+        <View style={styles.form}>
+          <TextField
+            label="Email"
+            autoCapitalize="none"
+            autoCorrect={false}
+            keyboardType="email-address"
+            textContentType="username"
+            value={email}
+            onChangeText={setEmail}
+            returnKeyType="next"
+            placeholder="driver@foodify.com"
+          />
 
-            <PlatformBlurView intensity={65} tint="light" style={styles.glassCard}>
-              <Animated.View
-                style={[
-                  styles.card,
-                  {
-                    opacity: cardOpacity,
-                    transform: [{ translateY: cardTranslateY }],
-                  },
-                ]}
-              >
-                <View style={styles.logoWrapper}>
-                  <Logo />
-                </View>
+          <TextField
+            label="Password"
+            autoCapitalize="none"
+            autoCorrect={false}
+            secureTextEntry
+            textContentType="password"
+            value={password}
+            onChangeText={setPassword}
+            returnKeyType="done"
+            placeholder="Enter your password"
+            containerStyle={styles.passwordField}
+            onSubmitEditing={handleSubmit}
+          />
 
-                <View style={styles.headlineWrapper}>
-                  <Text allowFontScaling={false} style={styles.headline}>
-                    Welcome back, Rider
-                  </Text>
-                  <Text allowFontScaling={false} style={styles.subtext}>
-                    Your next delivery is just a tap away
-                  </Text>
-                </View>
+          {error ? (
+            <Text allowFontScaling={false} style={styles.error}>
+              {error}
+            </Text>
+          ) : null}
 
-                <View style={styles.formWrapper}>
-                  <TextField
-                    placeholder="Your Number eg. 98765432"
-                    keyboardType="phone-pad"
-                    value={phoneNumber}
-                    onChangeText={setPhoneNumber}
-                    autoCapitalize="none"
-                    containerStyle={styles.input}
-                  />
-                  <Text allowFontScaling={false} style={styles.helperText}>
-                    We&apos;ll send a one-time code to verify your account.
-                  </Text>
-                </View>
-
-                <Button label="Continue" onPress={handleContinue} disabled={!isValidNumber} />
-              </Animated.View>
-            </PlatformBlurView>
-          </View>
-        </KeyboardAvoidingView>
+          <Button
+            label={isSubmitting ? 'Signing in…' : 'Sign in'}
+            onPress={handleSubmit}
+            disabled={!isFormValid || isSubmitting}
+            style={styles.submitButton}
+          />
+        </View>
       </View>
-    </View>
+    </KeyboardAvoidingView>
   );
 };
 
 const styles = StyleSheet.create({
-  safeArea: {
-    flex: 1,
-    backgroundColor: '#0F172A',
-  },
   container: {
     flex: 1,
-    backgroundColor: '#0F172A',
+    backgroundColor: '#F8FAFC',
   },
-  ambientLayer: {
-    ...StyleSheet.absoluteFillObject,
-  },
-  glow: {
-    position: 'absolute',
-    width: moderateScale(320),
-    height: moderateScale(320),
-    borderRadius: moderateScale(200),
-    opacity: 0.22,
-    shadowColor: 'rgba(251, 113, 133, 0.35)',
-    shadowOffset: { width: 0, height: verticalScale(12) },
-    shadowOpacity: 1,
-    shadowRadius: moderateScale(42),
-  },
-  glowTop: {
-    top: -moderateScale(120),
-    right: -moderateScale(60),
-    backgroundColor: '#FB7185',
-  },
-  glowBottom: {
-    bottom: -moderateScale(140),
-    left: -moderateScale(80),
-    backgroundColor: '#60A5FA',
-    shadowColor: 'rgba(96, 165, 250, 0.32)',
-  },
-  glowAccent: {
-    position: 'absolute',
-    width: moderateScale(220),
-    height: moderateScale(220),
-    borderRadius: moderateScale(120),
-    backgroundColor: '#FDE68A',
-    opacity: 0.16,
-    top: moderateScale(140),
-    right: -moderateScale(40),
-    shadowColor: 'rgba(253, 230, 138, 0.5)',
-    shadowOffset: { width: 0, height: verticalScale(10) },
-    shadowOpacity: 1,
-    shadowRadius: moderateScale(28),
-  },
-  avoidingView: {
+  content: {
     flex: 1,
-  },
-  contentWrapper: {
-    flex: 1,
+    paddingHorizontal: 24,
+    paddingVertical: 32,
     justifyContent: 'center',
-    paddingHorizontal: moderateScale(24),
-    paddingVertical: verticalScale(32),
-    gap: verticalScale(18),
   },
-  badge: {
-    alignSelf: 'flex-start',
-    paddingHorizontal: moderateScale(18),
-    paddingVertical: verticalScale(8),
-    borderRadius: moderateScale(999),
-    backgroundColor: 'rgba(59, 130, 246, 0.18)',
-    borderWidth: StyleSheet.hairlineWidth,
-    borderColor: 'rgba(191, 219, 254, 0.45)',
-  },
-  badgeLabel: {
-    color: '#E0F2FE',
-    fontSize: moderateScale(12),
-    letterSpacing: moderateScale(0.4),
-    fontWeight: '600',
-  },
-  glassCard: {
-    borderRadius: moderateScale(34),
-    overflow: 'hidden',
-    borderWidth: StyleSheet.hairlineWidth,
-    borderColor: 'rgba(255, 255, 255, 0.18)',
-    backgroundColor: 'rgba(255, 255, 255, 0.08)',
-  },
-  card: {
-    paddingHorizontal: moderateScale(28),
-    paddingVertical: verticalScale(36),
-    gap: verticalScale(32),
-    backgroundColor: 'rgba(248, 250, 252, 0.96)',
-  },
-  logoWrapper: {
+  header: {
     alignItems: 'center',
+    marginBottom: 48,
   },
-  headlineWrapper: {
-    alignItems: 'center',
-    gap: verticalScale(6),
-  },
-  headline: {
-    fontSize: moderateScale(22),
-    fontWeight: '800',
+  title: {
+    marginTop: 24,
+    fontSize: 28,
+    fontWeight: '700',
     color: '#0F172A',
-    letterSpacing: moderateScale(0.6),
+    letterSpacing: 0.3,
   },
-  subtext: {
-    fontSize: moderateScale(14),
-    color: '#4B5563',
+  subtitle: {
+    marginTop: 12,
+    fontSize: 15,
+    lineHeight: 20,
+    color: '#475569',
     textAlign: 'center',
   },
-  formWrapper: {
-    gap: verticalScale(12),
+  form: {
+    gap: 18,
   },
-  input: {
-    marginTop: verticalScale(4),
+  passwordField: {
+    marginTop: -6,
   },
-  helperText: {
-    fontSize: moderateScale(12),
-    color: '#6B7280',
+  error: {
+    color: '#ef4444',
+    fontSize: 14,
+    fontWeight: '600',
     textAlign: 'center',
-    lineHeight: verticalScale(16),
+  },
+  submitButton: {
+    marginTop: 12,
   },
 });

--- a/foodify-driver/src/screens/Home/DashboardScreen.tsx
+++ b/foodify-driver/src/screens/Home/DashboardScreen.tsx
@@ -30,9 +30,9 @@ const DEFAULT_REGION = {
 };
 
 export const DashboardScreen: React.FC = () => {
-  const { phoneNumber, toggleOnlineStatus, isOnline } = useAuth();
+  const { user, toggleOnlineStatus, isOnline } = useAuth();
 
-  const formattedName = (phoneNumber ? phoneNumber : 'RIDER').toUpperCase();
+  const formattedName = (user?.name || user?.email || 'Driver').toUpperCase();
   const [userRegion, setUserRegion] = useState<Region | null>(null);
   const mapRef = useRef<MapViewType | null>(null);
   const [isIncomingOrderVisible, setIncomingOrderVisible] = useState<boolean>(true);

--- a/foodify-driver/src/services/authService.ts
+++ b/foodify-driver/src/services/authService.ts
@@ -1,0 +1,11 @@
+import { apiClient } from './api';
+import type { LoginResponse } from '../types/auth';
+
+export const loginDriver = async (email: string, password: string): Promise<LoginResponse> => {
+  const response = await apiClient.post<LoginResponse>('/api/auth/driver/login', {
+    email,
+    password,
+  });
+
+  return response.data;
+};

--- a/foodify-driver/src/store/authStore.ts
+++ b/foodify-driver/src/store/authStore.ts
@@ -2,6 +2,8 @@ import * as SecureStore from 'expo-secure-store';
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 
+import type { DriverUser, LoginResponse } from '../types/auth';
+
 type MemoryStore = Record<string, string>;
 
 type SecureStoreModule = typeof SecureStore & {
@@ -9,11 +11,11 @@ type SecureStoreModule = typeof SecureStore & {
 };
 
 export type AuthState = {
-  phoneNumber: string;
-  token?: string;
+  user: DriverUser | null;
+  accessToken: string | null;
+  refreshToken: string | null;
   isOnline: boolean;
-  setPhoneNumber: (phone: string) => void;
-  authenticate: (phone: string, token: string) => void;
+  authenticate: (payload: LoginResponse) => void;
   logout: () => void;
   toggleOnlineStatus: () => void;
 };
@@ -98,20 +100,33 @@ export const useAuthStore = create<AuthState>(
         updater: (state: AuthState) => AuthState | Partial<AuthState>,
       ) => void,
     ) => ({
-      phoneNumber: '',
-      token: undefined,
+      user: null,
+      accessToken: null,
+      refreshToken: null,
       isOnline: false,
-      setPhoneNumber: (phoneNumber: string) => set(() => ({ phoneNumber })),
-      authenticate: (phoneNumber: string, token: string) => set(() => ({ phoneNumber, token })),
-      logout: () => set(() => ({ token: undefined, isOnline: false, phoneNumber: '' })),
+      authenticate: ({ user, accessToken, refreshToken }: LoginResponse) =>
+        set(() => ({
+          user,
+          accessToken,
+          refreshToken,
+          isOnline: user?.available ?? false,
+        })),
+      logout: () =>
+        set(() => ({
+          user: null,
+          accessToken: null,
+          refreshToken: null,
+          isOnline: false,
+        })),
       toggleOnlineStatus: () => set((state) => ({ isOnline: !state.isOnline })),
     }),
     {
       name: 'foodify-driver-auth',
       storage: createJSONStorage(() => secureStorage),
       partialize: (state: AuthState) => ({
-        phoneNumber: state.phoneNumber,
-        token: state.token,
+        user: state.user,
+        accessToken: state.accessToken,
+        refreshToken: state.refreshToken,
         isOnline: state.isOnline,
       }),
     },

--- a/foodify-driver/src/types/auth.ts
+++ b/foodify-driver/src/types/auth.ts
@@ -1,0 +1,17 @@
+export type DriverUser = {
+  id: number;
+  email: string;
+  password?: string;
+  authProvider: string;
+  name: string;
+  enabled: boolean;
+  role: string;
+  available: boolean;
+  phone: string | null;
+};
+
+export type LoginResponse = {
+  user: DriverUser;
+  accessToken: string;
+  refreshToken: string;
+};

--- a/foodify-driver/src/types/external.d.ts
+++ b/foodify-driver/src/types/external.d.ts
@@ -18,9 +18,13 @@ declare module 'expo-secure-store' {
 declare module 'axios' {
   export type AxiosRequestConfig = Record<string, unknown>;
   export type AxiosResponse<T = any> = { data: T } & Record<string, unknown>;
-  export type AxiosError = Error & { response?: AxiosResponse };
+  export type AxiosError<T = any> = Error & {
+    code?: string;
+    response?: AxiosResponse<T>;
+  };
   export interface AxiosInstance {
     (config: AxiosRequestConfig): Promise<AxiosResponse>;
+    post<T = any>(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<AxiosResponse<T>>;
     create: (config?: AxiosRequestConfig) => AxiosInstance;
     interceptors: {
       request: { use: (fulfilled: (config: AxiosRequestConfig) => AxiosRequestConfig, rejected?: (error: any) => any) => void };
@@ -32,6 +36,7 @@ declare module 'axios' {
       };
     };
   }
+  export function isAxiosError<T = any>(payload: unknown): payload is AxiosError<T>;
   const axios: AxiosInstance;
   export default axios;
 }
@@ -70,6 +75,7 @@ declare module 'react-native-maps' {
     provider?: 'google' | 'default';
     initialRegion?: Region;
     customMapStyle?: Array<Record<string, unknown>>;
+    ref?: unknown;
   };
 
   export type MarkerProps = ViewProps & {
@@ -88,6 +94,20 @@ declare module 'react-native-maps' {
   export const Marker: ComponentType<MarkerProps>;
 
   export default MapView;
+}
+
+declare module 'react-native-safe-area-context' {
+  import type { ReactNode } from 'react';
+
+  export type EdgeInsets = {
+    top: number;
+    bottom: number;
+    left: number;
+    right: number;
+  };
+
+  export const SafeAreaProvider: React.FC<{ children?: ReactNode }>;
+  export function useSafeAreaInsets(): EdgeInsets;
 }
 
 declare module 'react-native-size-matters' {


### PR DESCRIPTION
## Summary
- replace the animated phone-number login with a simple email/password form wired to the driver login API
- persist the authenticated driver profile and tokens in the auth store and add a dedicated login service
- refresh supporting types and navigation logic for the new authentication shape

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68e45645aef8832c9d36c86871c5f4e6